### PR TITLE
Add delay to sendText

### DIFF
--- a/docs/api/classes/Conversation.md
+++ b/docs/api/classes/Conversation.md
@@ -14,11 +14,11 @@ const convo = new Conversation(
 );
 
 await convo.waitForConversationToStart();
-convo.sendText('hi');
+await convo.sendText('hi');
 
 await convo.waitForResponseContaining('Is this an example?');
 
-convo.sendText('yes');
+await convo.sendText('yes');
 
 const reply = await convo.waitForResponse();
 console.log(reply);
@@ -60,23 +60,24 @@ console.log(reply);
 
 ### sendText
 
-▸ **sendText**(`text`): `void`
+▸ **sendText**(`text`, `delayInMs?`): `Promise`<`void`\>
 
 Sends text to the conversation
 
 #### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `text` | `string` | Text containing at least one character |
+| Name | Type | Default value | Description |
+| :------ | :------ | :------ | :------ |
+| `text` | `string` | `undefined` | Text containing at least one character |
+| `delayInMs` | `number` | `2000` | Delay in milliseconds between calling this method and the text being sent. Without a delay some messages are sent so quickly after the original message that Genesys Cloud doesn't acknowledge them. A delay of 0 will result in the text being sent immediately. |
 
 #### Returns
 
-`void`
+`Promise`<`void`\>
 
 #### Defined in
 
-[packages/genesys-web-messaging-tester/src/Conversation.ts:162](https://github.com/ovotech/genesys-web-messaging-tester/blob/main/packages/genesys-web-messaging-tester/src/Conversation.ts#L162)
+[packages/genesys-web-messaging-tester/src/Conversation.ts:166](https://github.com/ovotech/genesys-web-messaging-tester/blob/main/packages/genesys-web-messaging-tester/src/Conversation.ts#L166)
 
 ___
 
@@ -113,7 +114,7 @@ If you want to wait for a specific message use [waitForResponseWithTextContainin
 
 #### Defined in
 
-[packages/genesys-web-messaging-tester/src/Conversation.ts:175](https://github.com/ovotech/genesys-web-messaging-tester/blob/main/packages/genesys-web-messaging-tester/src/Conversation.ts#L175)
+[packages/genesys-web-messaging-tester/src/Conversation.ts:188](https://github.com/ovotech/genesys-web-messaging-tester/blob/main/packages/genesys-web-messaging-tester/src/Conversation.ts#L188)
 
 ___
 
@@ -145,7 +146,7 @@ use [waitForResponseText](Conversation.md#waitforresponsetext).
 
 #### Defined in
 
-[packages/genesys-web-messaging-tester/src/Conversation.ts:233](https://github.com/ovotech/genesys-web-messaging-tester/blob/main/packages/genesys-web-messaging-tester/src/Conversation.ts#L233)
+[packages/genesys-web-messaging-tester/src/Conversation.ts:246](https://github.com/ovotech/genesys-web-messaging-tester/blob/main/packages/genesys-web-messaging-tester/src/Conversation.ts#L246)
 
 ___
 
@@ -167,4 +168,4 @@ Wait for all responses until there is a predefined amount of 'silence'.
 
 #### Defined in
 
-[packages/genesys-web-messaging-tester/src/Conversation.ts:191](https://github.com/ovotech/genesys-web-messaging-tester/blob/main/packages/genesys-web-messaging-tester/src/Conversation.ts#L191)
+[packages/genesys-web-messaging-tester/src/Conversation.ts:204](https://github.com/ovotech/genesys-web-messaging-tester/blob/main/packages/genesys-web-messaging-tester/src/Conversation.ts#L204)

--- a/examples/api/__tests__/using-jest.spec.ts
+++ b/examples/api/__tests__/using-jest.spec.ts
@@ -24,7 +24,7 @@ describe('Using jest to perform the test', () => {
     const convo = new Conversation(session);
     await convo.waitForConversationToStart();
 
-    convo.sendText('hi');
+    await convo.sendText('hi');
 
     await expect(
       convo.waitForResponseWithTextContaining(
@@ -35,7 +35,7 @@ describe('Using jest to perform the test', () => {
       ),
     ).resolves.toBeDefined();
 
-    convo.sendText('Yes');
+    await convo.sendText('Yes');
 
     await expect(convo.waitForResponseText()).resolves.toContain(
       'Thank you! Now for the next question...',
@@ -58,7 +58,7 @@ describe('Using jest to perform the test', () => {
     // Log interactions as they occur
     transcriber.on('messageTranscribed', (t) => console.log(t.toString()));
 
-    convo.sendText('hi');
+    await convo.sendText('hi');
 
     await expect(convo.waitForResponseText()).resolves.toContain(
       'Can we ask you some questions about your experience today?',

--- a/examples/api/src/js-script.js
+++ b/examples/api/src/js-script.js
@@ -12,13 +12,13 @@ const WebMsgTester = require('@ovotech/genesys-web-messaging-tester');
   const convo = new WebMsgTester.Conversation(session);
   await convo.waitForConversationToStart();
 
-  convo.sendText('hi');
+  await convo.sendText('hi');
 
   await convo.waitForResponseWithTextContaining(
     'Can we ask you some questions about your experience today?',
   );
 
-  convo.sendText('Yes');
+  await convo.sendText('Yes');
 
   await convo.waitForResponseWithTextContaining('Thank you! Now for the next question...');
 

--- a/examples/api/src/ts-script.ts
+++ b/examples/api/src/ts-script.ts
@@ -21,7 +21,7 @@ require('dotenv').config({ path: '../../.env' });
   // Wait for the conversation to start before sending the message
   await convo.waitForConversationToStart();
 
-  convo.sendText('hi');
+  await convo.sendText('hi');
 
   // Waits for response containing text. Error thrown if exceeds timeout
   await convo.waitForResponseWithTextContaining(
@@ -32,7 +32,7 @@ require('dotenv').config({ path: '../../.env' });
     },
   );
 
-  convo.sendText('Yes');
+  await convo.sendText('Yes');
   // test-section
 
   await convo.waitForResponseWithTextContaining('Thank you! Now for the next question...', {

--- a/packages/genesys-web-messaging-tester-cli/package.json
+++ b/packages/genesys-web-messaging-tester-cli/package.json
@@ -27,7 +27,7 @@
     "web-messaging-tester": "lib/index.js"
   },
   "dependencies": {
-    "@ovotech/genesys-web-messaging-tester": "^2.0.1",
+    "@ovotech/genesys-web-messaging-tester": "^2.0.2",
     "chalk": "^4.1.2",
     "ci-info": "^3.5.0",
     "commander": "^8.3.0",

--- a/packages/genesys-web-messaging-tester-cli/src/testScript/parseTestScript.ts
+++ b/packages/genesys-web-messaging-tester-cli/src/testScript/parseTestScript.ts
@@ -31,11 +31,12 @@ export function parseScenarioStep(
   step: TestScriptFileScenarioStep,
 ): (convo: Conversation, context: StepContext) => Promise<unknown | void> {
   if ('say' in step) {
-    return async (convo) => convo.sendText(step.say);
+    return async (convo) => await convo.sendText(step.say);
   }
 
   if ('waitForReplyContaining' in step) {
-    return async (convo) => convo.waitForResponseWithTextContaining(step.waitForReplyContaining);
+    return async (convo) =>
+      await convo.waitForResponseWithTextContaining(step.waitForReplyContaining);
   }
 
   throw new Error(`Unsupported step ${step}`);

--- a/packages/genesys-web-messaging-tester/README.md
+++ b/packages/genesys-web-messaging-tester/README.md
@@ -19,11 +19,11 @@ const session = new WebMessengerGuestSession({
 const convo = new Conversation(session);
 await convo.waitForConversationToStart();
 
-convo.sendText('hi');
+await convo.sendText('hi');
 
 await convo.waitForResponseContaining('Please enter your account number');
 
-convo.sendText('123');
+await convo.sendText('123');
 
 await convo.waitForResponseContaining('Your account number is too short. It is the 6 digit number on your bills');
 ```
@@ -52,13 +52,13 @@ const WebMsgTester = require('@ovotech/genesys-web-messaging-tester');
   const convo = new WebMsgTester.Conversation(session);
   await convo.waitForConversationToStart();
 
-  convo.sendText('hi');
+  await convo.sendText('hi');
 
   await convo.waitForResponseWithTextContaining(
     'Can we ask you some questions about your experience today?',
   );
 
-  convo.sendText('Yes');
+  await convo.sendText('Yes');
 
   await convo.waitForResponseWithTextContaining('Thank you! Now for the next question...');
 

--- a/packages/genesys-web-messaging-tester/package.json
+++ b/packages/genesys-web-messaging-tester/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ovotech/genesys-web-messaging-tester",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "license": "Apache-2.0",

--- a/packages/genesys-web-messaging-tester/src/Conversation.ts
+++ b/packages/genesys-web-messaging-tester/src/Conversation.ts
@@ -110,11 +110,11 @@ Received before disconnection:
  * );
  *
  * await convo.waitForConversationToStart();
- * convo.sendText('hi');
+ * await convo.sendText('hi');
  *
  * await convo.waitForResponseContaining('Is this an example?');
  *
- * convo.sendText('yes');
+ * await convo.sendText('yes');
  *
  * const reply = await convo.waitForResponse();
  * console.log(reply);
@@ -158,13 +158,26 @@ export class Conversation {
   /**
    * Sends text to the conversation
    * @param text Text containing at least one character
+   * @param delayInMs Delay in milliseconds between calling this method and the text being sent.
+   *                  Without a delay some messages are sent so quickly after the original message
+   *                  that Genesys Cloud doesn't acknowledge them.
+   *                  A delay of 0 will result in the text being sent immediately.
    */
-  public sendText(text: string): void {
+  public async sendText(text: string, delayInMs = 2000): Promise<void> {
     if (text.length === 0) {
       throw new Error('Text cannot be empty');
     }
 
-    this.messengerSession.sendText(text);
+    if (delayInMs > 0) {
+      return new Promise<void>((resolve) => {
+        setTimeout(() => {
+          this.messengerSession.sendText(text);
+          resolve();
+        }, delayInMs);
+      });
+    } else {
+      this.messengerSession.sendText(text);
+    }
   }
 
   /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -907,7 +907,7 @@ __metadata:
   resolution: "@ovotech/genesys-web-messaging-tester-cli@workspace:packages/genesys-web-messaging-tester-cli"
   dependencies:
     "@ikerin/build-readme": ^1.1.1
-    "@ovotech/genesys-web-messaging-tester": ^2.0.1
+    "@ovotech/genesys-web-messaging-tester": ^2.0.2
     "@types/humanize-duration": ^3.27.1
     "@types/jest": ^29.0.3
     "@types/jest-when": ^2.7.4
@@ -950,7 +950,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@ovotech/genesys-web-messaging-tester@*, @ovotech/genesys-web-messaging-tester@^2.0.1, @ovotech/genesys-web-messaging-tester@workspace:packages/genesys-web-messaging-tester":
+"@ovotech/genesys-web-messaging-tester@*, @ovotech/genesys-web-messaging-tester@^2.0.2, @ovotech/genesys-web-messaging-tester@workspace:packages/genesys-web-messaging-tester":
   version: 0.0.0-use.local
   resolution: "@ovotech/genesys-web-messaging-tester@workspace:packages/genesys-web-messaging-tester"
   dependencies:


### PR DESCRIPTION
Add delay to sending text to resolve #38.

I've added the delay to the `sendText` method to remove the need for someone to understand this sporadic problem when calling the method directly after receiving a response.